### PR TITLE
[ci skip] bump go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is not an officially supported Google product.
 
 ### Requirements
 
-* [Golang](https://golang.org/dl/) 1.7
+* [Golang](https://golang.org/dl/) 1.9
 
 ### Build
 


### PR DESCRIPTION
We're using 1.9 in Travis so bump this up to match it