### PR TITLE
Add setting to avoid subscription creation

### DIFF
--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -159,6 +159,11 @@ func createPubsubClient(config *config.Config) (*pubsub.Client, error) {
 }
 
 func getOrCreateSubscription(client *pubsub.Client, config *config.Config) (*pubsub.Subscription, error) {
+	if !config.Subscription.Create {
+		subscription := client.Subscription(config.Subscription.Name)
+		return subscription, nil
+	}
+
 	topic := client.Topic(config.Topic)
 	ctx := context.Background()
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 		Name                string        `config:"name" validate:"required"`
 		RetainAckedMessages bool          `config:"retain_acked_messages"`
 		RetentionDuration   time.Duration `config:"retention_duration"`
+		Create              bool          `config:"create"`
 	}
 	Json struct {
 		Enabled     bool `config:"enabled"`
@@ -39,7 +40,13 @@ type Config struct {
 	}
 }
 
-var DefaultConfig = Config{}
+func GetDefaultConfig() Config {
+	config := Config{}
+	config.Subscription.Create = true
+	return config
+}
+
+var DefaultConfig = GetDefaultConfig()
 
 func GetAndValidateConfig(cfg *common.Config) (*Config, error) {
 	c := DefaultConfig

--- a/pubsubbeat.yml
+++ b/pubsubbeat.yml
@@ -21,9 +21,11 @@ pubsubbeat:
   # The Pub/Sub topic name. You must first create this topic.
   topic: my-topic
 
-  # The Pub/Sub subscription name. If the subscription does not exist,
-  # Pubsubbeat will attempt to create the subscription.
+  # The Pub/Sub subscription name.
   subscription.name: my-subscription
+
+  # Attempt to create the subscription.
+  subscription.create: true # Defaults to true
 
   # The settings below are used only if the Beat creates the subscription.
 


### PR DESCRIPTION
Add a configuration property that will skip attempting to create the
pubsub subscription.

For https://github.com/GoogleCloudPlatform/pubsubbeat/issues/13

Note the default subscriber role still will not work, minimal
permissions can be granted as described here
https://github.com/googleapis/google-cloud-node/issues/1502#issuecomment-412147694.