### PR TITLE
Added ability to use JSON fields at root (#1)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@ Contributors:
 * Chris Koehnke (chris.koehnke@elastic.co)
 * Joseph Lewis III (jlewisiii@google.com)
 * Vincent Roseberry (rosbo@google.com)
+* Andrew Teall (andrewteall@gmail.com)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 pubsubbeat, and you aren't on the list above and want to be, please let us know

--- a/config/config.go
+++ b/config/config.go
@@ -35,14 +35,19 @@ type Config struct {
 		Create              bool          `config:"create"`
 	}
 	Json struct {
-		Enabled     bool `config:"enabled"`
-		AddErrorKey bool `config:"add_error_key"`
+		Enabled               bool   `config:"enabled"`
+		AddErrorKey           bool   `config:"add_error_key"`
+		FieldsUnderRoot       bool   `config:"fields_under_root"`
+		FieldsUseTimestamp    bool   `config:"fields_use_timestamp"`
+		FieldsTimestampName   string `config:"fields_timestamp_name"`
+		FieldsTimestampFormat string `config:"fields_timestamp_format"`
 	}
 }
 
 func GetDefaultConfig() Config {
 	config := Config{}
 	config.Subscription.Create = true
+	config.Json.FieldsTimestampName = "@timestamp"
 	return config
 }
 

--- a/pubsubbeat.reference.yml
+++ b/pubsubbeat.reference.yml
@@ -53,6 +53,28 @@ pubsubbeat:
   # but cannot be used.
   json.add_error_key: false
 
+  # If this option is set to true and json.enabled is set to true, the json
+  # fields are stored as top-level fields in the output document instead of
+  # being grouped under a json sub-dictionary. Default is false.
+  #json.fields_under_root: false
+
+  # If this option is set to true and json.enabled is set to true, the @timestamp
+  # value in the in the json fields will be used as the timestamp instead of
+  # using time.Now(). A timestamp format must be supplied via
+  # json_fields_timestamp_format:. Default is false.
+  #json.fields_use_timestamp: false
+
+  # If this option is set and json_fields_use_timestamp is set to true,
+  # the provided value will be used as the field for time to be converted.
+  # Default "@timestamp"
+  #json.fields_timestamp_name: "@timestamp"
+
+  # If this option is set to true and json_fields_use_timestamp is set to true,
+  # the provided value will be used as the golang time format to attempt to
+  # convert the json timestamp to the published time. The format is golang time
+  # format.
+  #json.fields_timestamp_format: ""
+
 #================================ General ======================================
 
 # The name of the shipper that publishes the network data. It can be used to group


### PR DESCRIPTION
This solves https://github.com/GoogleCloudPlatform/pubsubbeat/issues/16. There were some issue if the timestamp fields alreayd existed so I also added a way to override the timestamp field so that it's treaat correctly as time.

* Added Config to allow JSON fields ot be stored as root objects instead of being nested under json

* Added ability to use the @timestamp provided in JSON fields to be used as the event timestamp

* Fixed Config references

* Fix code to reference the configs

* Fix overloaded time variable

* Fix overloaded time variable again

* Fixed error claiming datetime was unused

* Fixed error claiming datetime was unused

* Actually Fixed error claiming datetime was unused

* Restructure to allow correct initializations

* Update config parameters to match rest of file

* Remove extra time set when failing to parse time

* Fix unmarshall error scope

* Added Parameter for custom timestamp field name

* Remove TODO and change scope of unmarshal Error