### PR TITLE
Prevent returning an error first time subscription is created

### DIFF
--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -198,7 +198,7 @@ func getOrCreateSubscription(client *pubsub.Client, config *config.Config) (*pub
 		subscription = client.Subscription(config.Subscription.Name)
 	} else if ok && st.Code() == codes.NotFound {
 		return nil, fmt.Errorf("topic %q does not exists", config.Topic)
-	} else {
+	} else if err != nil {
 		return nil, fmt.Errorf("fail to create subscription: %v", err)
 	}
 


### PR DESCRIPTION
The first time a subscription is created, the current code will error out with`fail to create subscription: <nil>` because the else case here makes `return subscription, nil` inaccessible. This modification to check if err != nil should let the code proceed correctly when a subscription is created.