### PR TITLE
Reduce mutex contention in client.Publish() by batching events

### DIFF
--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -108,7 +108,7 @@ func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 	events := make(chan ackableEvent)
 
 	go func() {
-		// batch up documents to prevent contending on lock in client.Publish()
+		// Batch up documents to prevent contending on lock in client.Publish()
 
 		batchMaxSize := 512
 		batchMaxTime := 1 * time.Second
@@ -127,7 +127,6 @@ func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 				if len(batch) == batchMaxSize {
 					bt.client.PublishAll(batch)
 					for _, a := range batchAcks {
-						// TODO: Evaluate using AckHandler.
 						a.Ack()
 					}
 					batch = make([]beat.Event, 0, batchMaxSize)
@@ -136,7 +135,6 @@ func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 			case <-t:
 				bt.client.PublishAll(batch)
 				for _, a := range batchAcks {
-					// TODO: Evaluate using AckHandler.
 					a.Ack()
 				}
 				batch = make([]beat.Event, 0, batchMaxSize)


### PR DESCRIPTION
As part of testing out the fix for https://github.com/GoogleCloudPlatform/pubsubbeat/issues/35, we saw a bottleneck at ~18 MB/s ingress with the new 1.3.0-rc build.

We were able to get more throughput by running two pubsubbeat processes, suggesting an internal bottleneck. After some pprof profiling with an eye on lock contention, I saw this:

![image](https://user-images.githubusercontent.com/11158255/72911905-2321bd80-3d3b-11ea-9d7e-64ca3d7d0e0b.png)

When looking at the implementation of the libbeat client, there is a `Publish()` function which will lock on every call. Since `Publish()` is being called by multiple pubsub client goroutines in the critical path, there is a lot of contention.

Luckily, there is a `PublishAll()` function that allows events to be batched up with the lock being held for the entire batch.

This patch batches messages coming in from pubsub and calls `PublishAll()` in batches of 512 messages or once every second (whichever happens first).

With this patch we managed to max out ES at 30+ MB/s ingress. We also saw significantly reduced context switches on pubsubbeat. Here is the indexing rate of pubsubbeat 1.2.0, 1.3.0-rc, and then this patched version:

![image](https://user-images.githubusercontent.com/11158255/72912944-ae4f8300-3d3c-11ea-81db-50889806ee1c.png)

A potential downside of this change: Increased allocations puts more pressure on the garbage collector. I'm happy for input here in case that's a concern.