### PR TITLE
support gzip decompression

### DIFF
--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -120,7 +120,7 @@ func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 			eventMap["attributes"] = m.Attributes
 		}
 
-		if m.Attributes["pubsubbeat.gzip"] == "true" {
+		if m.Attributes["pubsubbeat.compression"] == "gzip" {
 			err = bt.decompress(m)
 			if err != nil {
 				bt.logger.Warnf("failed to decompress gzip: %s", err)


### PR DESCRIPTION
JSON is not a very efficient format. While a binary format would arguably be even better, compression at least allows us to trade-off storage for CPU.

While the savings on single messages is going to be limited, I'd expect to see more significant savings when combining this with batching. This patch is designed as a first building block.

The goal is to then add batching / multiline / ndjson support on top of this, allowing compression across multiple JSON documents.

This is roughly based on the patch from @heldtogether in https://github.com/googleapis/google-cloud-go/issues/1546.