### PR TITLE
support for batching via ndjson

### DIFF
--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -123,14 +123,11 @@ func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 				"type":         b.Info.Name,
 				"message_id":   m.ID,
 				"publish_time": m.PublishTime,
+				"message":      string(rawRecord),
 			}
 
 			if len(m.Attributes) > 0 {
 				eventMap["attributes"] = m.Attributes
-			}
-
-			if m.Attributes["pubsubbeat.ndjson"] != "true" {
-				eventMap["message"] = string(m.Data)
 			}
 
 			if bt.config.Json.Enabled {


### PR DESCRIPTION
This patch allows multiple newline-delimited JSON objects to be batched together in a single pubsub message.

Doing this provides two benefits:

* Much more effective compression when paired with https://github.com/GoogleCloudPlatform/pubsubbeat/pull/44
* Reducing lock contention via `PublishAll` (see also https://github.com/GoogleCloudPlatform/pubsubbeat/pull/40)

I still need to integration test this, but I think it's ready for feedback on the general idea and approach.