### PR TITLE
support dropping message field

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -59,3 +59,7 @@ pubsubbeat:
   # in case of JSON unmarshaling errors or when a text key is defined in the configuration
   # but cannot be used.
   json.add_error_key: false
+
+  # If this setting is enabled, the "message" field is set with the raw plaintext
+  # message.
+  json.fields_keep_message: true # Defaults to true, for BC

--- a/_meta/fields.generated.yml
+++ b/_meta/fields.generated.yml
@@ -5,7 +5,7 @@
   fields:
     - name: message
       type: text
-      required: true
+      required: false
       description: >
         Plain text message payload
     - name: json

--- a/_meta/fields.yml
+++ b/_meta/fields.yml
@@ -5,7 +5,7 @@
   fields:
     - name: message
       type: text
-      required: true
+      required: false
       description: >
         Plain text message payload
     - name: json

--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -144,6 +144,10 @@ func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 					}
 				}
 			}
+
+			if !bt.config.Json.FieldsKeepMessage {
+				delete(eventMap, "message")
+			}
 		}
 
 		if datetime.IsZero() {

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 		FieldsUseTimestamp    bool   `config:"fields_use_timestamp"`
 		FieldsTimestampName   string `config:"fields_timestamp_name"`
 		FieldsTimestampFormat string `config:"fields_timestamp_format"`
+		FieldsKeepMessage     bool   `config:"fields_keep_message"`
 	}
 }
 
@@ -52,6 +53,7 @@ func GetDefaultConfig() Config {
 	config.Subscription.ConnectionPoolSize = 1
 	config.Subscription.Create = true
 	config.Json.FieldsTimestampName = "@timestamp"
+	config.Json.FieldsKeepMessage = true
 	return config
 }
 


### PR DESCRIPTION
Pubsubbeat by default includes a `message` field that contains the original bytes from the pubsub message. This adds a lot of unnecessary data to events that are json parsed, basically duplicating the data under the json key.

While it is possible to remove this field using something like this:

```
processors:
  # message is parsed, no need to keep the raw json
  - drop_fields:
      fields: ['message']
```

I found it rather surprising behaviour. After all, ES already stores the original JSON document under `_source`. Therefore, it might be good to have a setting to make this easier to disable.

I've set the default to `true` for BC reasons.